### PR TITLE
NumPy arrays rework

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -807,7 +807,7 @@ template <typename base, typename holder> struct is_holder_type :
 template <typename base, typename deleter> struct is_holder_type<base, std::unique_ptr<base, deleter>> :
     std::true_type {};
 
-template<typename T> struct handle_load_options { enum { ignore_error_already_set = false }; };
+template<typename T> struct load_options { enum { propagate_errors = 0 }; };
 
 template <typename T> struct handle_type_name { static PYBIND11_DESCR name() { return _<T>(); } };
 template <> struct handle_type_name<bytes> { static PYBIND11_DESCR name() { return _(PYBIND11_BYTES_NAME); } };
@@ -819,7 +819,7 @@ struct type_caster<type, typename std::enable_if<std::is_base_of<handle, type>::
 public:
     template <typename T = type, typename std::enable_if<!std::is_base_of<object, T>::value, int>::type = 0>
     bool load(handle src, bool /* convert */) {
-        if (!handle_load_options<type>::ignore_error_already_set) {
+        if (!load_options<type>::propagate_errors) {
             value = type(src); return value.check();
         } else {
             try { value = type(src); return value.check(); }
@@ -829,7 +829,7 @@ public:
 
     template <typename T = type, typename std::enable_if<std::is_base_of<object, T>::value, int>::type = 0>
     bool load(handle src, bool /* convert */) {
-        if (!handle_load_options<type>::ignore_error_already_set) {
+        if (!load_options<type>::propagate_errors) {
             value = type(src, true); return value.check();
         } else {
             try { value = type(src, true); return value.check(); }

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -155,7 +155,7 @@ public:
     PYBIND11_NOINLINE bool load(handle src, bool convert) {
         if (!src || !typeinfo)
             return false;
-        if (src.ptr() == Py_None) {
+        if (src.is_none()) {
             value = nullptr;
             return true;
         } else if (PyType_IsSubtype(Py_TYPE(src.ptr()), typeinfo->type)) {
@@ -180,7 +180,7 @@ public:
                                          const void *existing_holder = nullptr) {
         void *src = const_cast<void *>(_src);
         if (src == nullptr)
-            return handle(Py_None).inc_ref();
+            return none();
 
         auto &internals = get_internals();
 
@@ -408,7 +408,7 @@ template <> class type_caster<void_type> {
 public:
     bool load(handle, bool) { return false; }
     static handle cast(void_type, return_value_policy /* policy */, handle /* parent */) {
-        return handle(Py_None).inc_ref();
+        return none();
     }
     PYBIND11_TYPE_CASTER(void_type, _("None"));
 };
@@ -420,7 +420,7 @@ public:
     bool load(handle h, bool) {
         if (!h) {
             return false;
-        } else if (h.ptr() == Py_None) {
+        } else if (h.is_none()) {
             value = nullptr;
             return true;
         }
@@ -446,7 +446,7 @@ public:
         if (ptr)
             return capsule(ptr).release();
         else
-            return handle(Py_None).inc_ref();
+            return none();
     }
 
     template <typename T> using cast_op_type = void*&;
@@ -558,12 +558,12 @@ protected:
 template <> class type_caster<char> : public type_caster<std::string> {
 public:
     bool load(handle src, bool convert) {
-        if (src.ptr() == Py_None) return true;
+        if (src.is_none()) return true;
         return type_caster<std::string>::load(src, convert);
     }
 
     static handle cast(const char *src, return_value_policy /* policy */, handle /* parent */) {
-        if (src == nullptr) return handle(Py_None).inc_ref();
+        if (src == nullptr) return none();
         return PyUnicode_FromString(src);
     }
 
@@ -581,12 +581,12 @@ public:
 template <> class type_caster<wchar_t> : public type_caster<std::wstring> {
 public:
     bool load(handle src, bool convert) {
-        if (src.ptr() == Py_None) return true;
+        if (src.is_none()) return true;
         return type_caster<std::wstring>::load(src, convert);
     }
 
     static handle cast(const wchar_t *src, return_value_policy /* policy */, handle /* parent */) {
-        if (src == nullptr) return handle(Py_None).inc_ref();
+        if (src == nullptr) return none();
         return PyUnicode_FromWideChar(src, (ssize_t) wcslen(src));
     }
 
@@ -757,7 +757,7 @@ public:
     bool load(handle src, bool convert) {
         if (!src || !typeinfo) {
             return false;
-        } else if (src.ptr() == Py_None) {
+        } else if (src.is_none()) {
             value = nullptr;
             return true;
         } else if (PyType_IsSubtype(Py_TYPE(src.ptr()), typeinfo->type)) {

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -111,7 +111,7 @@ PYBIND11_NOINLINE inline std::string error_string() {
 
    std::string errorString;
     if (type) {
-        errorString += (std::string) handle(type).str();
+        errorString += handle(type).attr("__name__").cast<std::string>();
         errorString += ": ";
     }
     if (value)

--- a/include/pybind11/functional.h
+++ b/include/pybind11/functional.h
@@ -20,7 +20,7 @@ template <typename Return, typename... Args> struct type_caster<std::function<Re
     typedef typename std::conditional<std::is_same<Return, void>::value, void_type, Return>::type retval_type;
 public:
     bool load(handle src_, bool) {
-        if (src_.ptr() == Py_None)
+        if (src_.is_none())
             return true;
 
         src_ = detail::get_function(src_);
@@ -62,7 +62,7 @@ public:
     template <typename Func>
     static handle cast(Func &&f_, return_value_policy policy, handle /* parent */) {
         if (!f_)
-            return handle(Py_None).inc_ref();
+            return none();
 
         auto result = f_.template target<Return (*)(Args...)>();
         if (result)

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -30,12 +30,39 @@ namespace detail {
 template <typename type, typename SFINAE = void> struct npy_format_descriptor { };
 template <typename type> struct is_pod_struct;
 
+struct PyArrayDescr_Proxy {
+    PyObject_HEAD
+    PyObject *typeobj;
+    char kind;
+    char type;
+    char byteorder;
+    char flags;
+    int type_num;
+    int elsize;
+    int alignment;
+    char *subarray;
+    PyObject *fields;
+    PyObject *names;
+};
+
+struct PyArray_Proxy {
+    PyObject_HEAD
+    char *data;
+    int nd;
+    ssize_t *dimensions;
+    ssize_t *strides;
+    PyObject *base;
+    PyObject *descr;
+    int flags;
+};
+
 struct npy_api {
     enum constants {
         NPY_C_CONTIGUOUS_ = 0x0001,
         NPY_F_CONTIGUOUS_ = 0x0002,
-        NPY_ARRAY_FORCECAST_ = 0x0010,
         NPY_ENSURE_ARRAY_ = 0x0040,
+        NPY_ARRAY_ALIGNED_ = 0x0100,
+        NPY_ARRAY_WRITEABLE_ = 0x0400,
         NPY_BOOL_ = 0,
         NPY_BYTE_, NPY_UBYTE_,
         NPY_SHORT_, NPY_USHORT_,
@@ -112,6 +139,9 @@ private:
     }
 };
 }
+
+#define PyArray_GET(ptr, attr) (reinterpret_cast<::pybind11::detail::PyArray_Proxy*>(ptr)->attr)
+#define PyArrayDescr_GET(ptr, attr) (reinterpret_cast<::pybind11::detail::PyArrayDescr_Proxy*>(ptr)->attr)
 
 class dtype : public object {
 public:

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -294,6 +294,12 @@ public:
             result[i] = (size_t) PyArray_GET(m_ptr, dimensions)[i];
         return result;
     }
+
+    std::vector<size_t> strides() const {
+        std::vector<size_t> result(ndim());
+        for (size_t i = 0; i < ndim(); i++)
+            result[i] = (size_t) PyArray_GET(m_ptr, strides)[i];
+        return result;
     }
 
 protected:

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -326,21 +326,29 @@ public:
         return (size_t) PyArray_GET(m_ptr, nd);
     }
 
-    std::vector<size_t> shape() const {
-        std::vector<size_t> result(ndim());
-        for (size_t i = 0; i < ndim(); i++)
-            result[i] = (size_t) PyArray_GET(m_ptr, dimensions)[i];
-        return result;
+    const size_t* shape() const {
+        static_assert(sizeof(size_t) == sizeof(Py_intptr_t), "size_t != Py_intptr_t");
+        return reinterpret_cast<const size_t *>(PyArray_GET(m_ptr, dimensions));
     }
 
-    std::vector<size_t> strides() const {
-        std::vector<size_t> result(ndim());
-        for (size_t i = 0; i < ndim(); i++)
-            result[i] = (size_t) PyArray_GET(m_ptr, strides)[i];
-        return result;
+    size_t shape(size_t axis) const {
+        if (axis >= ndim())
+            pybind11_fail("NumPy: attempted to index shape beyond ndim");
+        return shape()[axis];
     }
 
-    data_ptr_t data() {
+    const size_t* strides() const {
+        static_assert(sizeof(size_t) == sizeof(Py_intptr_t), "size_t != Py_intptr_t");
+        return reinterpret_cast<const size_t *>(PyArray_GET(m_ptr, strides));
+    }
+
+    size_t strides(size_t axis) const {
+        if (axis >= ndim())
+            pybind11_fail("NumPy: attempted to index strides beyond ndim");
+        return strides()[axis];
+    }
+
+    data_ptr_t data() const {
         return reinterpret_cast<data_ptr_t>(PyArray_GET(m_ptr, data));
     }
 

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -413,11 +413,11 @@ public:
 template<typename T> using array_in_t = typename array_t<T>::in;
 template<typename T> using array_out_t = typename array_t<T>::out;
 
-template<int flags> struct detail::handle_load_options<generic_array<flags>> {
-    enum { ignore_error_already_set = true };
+template<int flags> struct detail::load_options<generic_array<flags>> {
+    enum { propagate_errors = 1 };
 };
-template<typename T, int flags> struct detail::handle_load_options<array_t<T, flags>> {
-    enum { ignore_error_already_set = true };
+template<typename T, int flags> struct detail::load_options<array_t<T, flags>> {
+    enum { propagate_errors = 1 };
 };
 
 template <typename T>

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -180,7 +180,7 @@ public:
     }
 
     size_t itemsize() const {
-        return attr("itemsize").cast<size_t>();
+        return (size_t) PyArrayDescr_GET(m_ptr, elsize);
     }
 
     bool has_fields() const {

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -283,6 +283,10 @@ public:
     pybind11::dtype dtype() const {
         return object(PyArray_GET(m_ptr, descr), true);
     }
+
+    size_t ndim() const {
+        return (size_t) PyArray_GET(m_ptr, nd);
+    }
     }
 
 protected:

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -287,6 +287,13 @@ public:
     size_t ndim() const {
         return (size_t) PyArray_GET(m_ptr, nd);
     }
+
+    std::vector<size_t> shape() const {
+        std::vector<size_t> result(ndim());
+        for (size_t i = 0; i < ndim(); i++)
+            result[i] = (size_t) PyArray_GET(m_ptr, dimensions)[i];
+        return result;
+    }
     }
 
 protected:

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -183,7 +183,7 @@ public:
         // This is essentially the same as calling np.dtype() constructor in Python
         PyObject *ptr = nullptr;
         if (!detail::npy_api::get().PyArray_DescrConverter_(args.release().ptr(), &ptr) || !ptr)
-            pybind11_fail("NumPy: failed to create structured dtype");
+            throw error_already_set();
         return object(ptr, false);
     }
 

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -187,8 +187,8 @@ public:
         return attr("fields").cast<object>().ptr() != Py_None;
     }
 
-    std::string kind() const {
-        return (std::string) attr("kind").cast<pybind11::str>();
+    char kind() const {
+        return PyArrayDescr_GET(m_ptr, kind);
     }
 
 private:
@@ -214,7 +214,7 @@ private:
             auto name = spec[0].cast<pybind11::str>();
             auto format = spec[1].cast<tuple>()[0].cast<dtype>();
             auto offset = spec[1].cast<tuple>()[1].cast<pybind11::int_>();
-            if (!len(name) && format.kind() == "V")
+            if (!len(name) && format.kind() == 'V')
                 continue;
             field_descriptors.push_back({(PYBIND11_STR_TYPE) name, format.strip_padding(), offset});
         }

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -265,6 +265,8 @@ public:
         m_ptr = ensure_array(m_ptr)
     )
 
+    using data_ptr_t = typename std::conditional<!!(flags & array_flags::writeable), void *, const void *>::type;
+
     enum {
         c_style = array_flags::c_style,
         f_style = array_flags::f_style,
@@ -338,6 +340,10 @@ public:
         return result;
     }
 
+    data_ptr_t data() {
+        return reinterpret_cast<data_ptr_t>(PyArray_GET(m_ptr, data));
+    }
+
 protected:
     template <typename T, typename SFINAE> friend struct detail::npy_format_descriptor;
 
@@ -397,6 +403,8 @@ public:
     using in = array_t<T, array_flags::in_flags>;
     using out = array_t<T, array_flags::out_flags>;
 
+    using data_ptr_t = typename std::conditional<!!(flags & array_flags::writeable), T *, const T *>::type;
+
     array_t() : base_t() { }
 
     array_t(const buffer_info& info) : base_t(info) { }
@@ -409,6 +417,10 @@ public:
 
     array_t(size_t count, T* ptr = nullptr)
     : base_t(count, ptr) { }
+
+    data_ptr_t data() {
+        return reinterpret_cast<data_ptr_t>(PyArray_GET(this->m_ptr, data));
+    }
 };
 template<typename T> using array_in_t = typename array_t<T>::in;
 template<typename T> using array_out_t = typename array_t<T>::out;

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -708,16 +708,13 @@ struct vectorize_helper {
         if (size == 1)
             return cast(f(*((Args *) buffers[Index].ptr)...));
 
-        array result(buffer_info(nullptr, sizeof(Return),
-            format_descriptor<Return>::format(),
-            ndim, shape, strides));
-
-        buffer_info buf = result.request();
-        Return *output = (Return *) buf.ptr;
+        array_t<Return> result(shape, strides);
+        auto buf = result.request();
+        auto output = (Return *) buf.ptr;
 
         if (trivial_broadcast) {
             /* Call the function */
-            for (size_t i=0; i<size; ++i) {
+            for (size_t i = 0; i < size; ++i) {
                 output[i] = f((buffers[Index].size == 1
                                ? *((Args *) buffers[Index].ptr)
                                : ((Args *) buffers[Index].ptr)[i])...);

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -280,8 +280,9 @@ public:
     array(const buffer_info &info)
     : array(pybind11::dtype(info), info.shape, info.strides, info.ptr) { }
 
-    pybind11::dtype dtype() {
-        return attr("dtype").cast<pybind11::dtype>();
+    pybind11::dtype dtype() const {
+        return object(PyArray_GET(m_ptr, descr), true);
+    }
     }
 
 protected:

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -184,7 +184,7 @@ public:
     }
 
     bool has_fields() const {
-        return attr("fields").cast<object>().ptr() != Py_None;
+        return PyArrayDescr_GET(m_ptr, names) != nullptr;
     }
 
     char kind() const {
@@ -201,13 +201,13 @@ private:
     dtype strip_padding() {
         // Recursively strip all void fields with empty names that are generated for
         // padding fields (as of NumPy v1.11).
-        auto fields = attr("fields").cast<object>();
-        if (fields.ptr() == Py_None)
+        if (!has_fields())
             return *this;
 
         struct field_descr { PYBIND11_STR_TYPE name; object format; pybind11::int_ offset; };
         std::vector<field_descr> field_descriptors;
 
+        auto fields = attr("fields").cast<object>();
         auto items = fields.attr("items").cast<object>();
         for (auto field : items()) {
             auto spec = object(field, true).cast<tuple>();

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1143,7 +1143,7 @@ inline void keep_alive_impl(handle nurse, handle patient) {
     if (!nurse || !patient)
         pybind11_fail("Could not activate keep_alive!");
 
-    if (patient.ptr() == Py_None || nurse.ptr() == Py_None)
+    if (patient.is_none() || nurse.is_none())
         return; /* Nothing to keep alive or nothing to be kept alive by */
 
     cpp_function disable_lifesupport(

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -40,6 +40,7 @@ public:
     inline detail::accessor attr(const char *key) const;
     inline pybind11::str str() const;
     inline pybind11::str repr() const;
+    bool is_none() const { return m_ptr == Py_None; }
     template <typename T> T cast() const;
     template <return_value_policy policy = return_value_policy::automatic_reference, typename ... Args>
     #if __cplusplus > 201103L

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -275,7 +275,7 @@ NAMESPACE_END(detail)
         Name(object&& o) noexcept : Parent(std::move(o)) { CvtStmt; } \
         Name& operator=(object&& o) noexcept { (void) object::operator=(std::move(o)); CvtStmt; return *this; } \
         Name& operator=(const object& o) { return static_cast<Name&>(object::operator=(o)); CvtStmt; } \
-        bool check() const { return m_ptr != nullptr && (bool) CheckFun(m_ptr); }
+        bool check() const { return this->m_ptr != nullptr && (bool) CheckFun(this->m_ptr); }
 
 #define PYBIND11_OBJECT(Name, Parent, CheckFun) \
     PYBIND11_OBJECT_CVT(Name, Parent, CheckFun, )

--- a/tests/test_eigen.py
+++ b/tests/test_eigen.py
@@ -94,7 +94,7 @@ def test_special_matrix_objects():
     asymm = np.array([[ 1,  2,  3,  4],
                       [ 5,  6,  7,  8],
                       [ 9, 10, 11, 12],
-                      [13, 14, 15, 16]])
+                      [13, 14, 15, 16]], np.int32)
     symm_lower = np.array(asymm)
     symm_upper = np.array(asymm)
     for i in range(4):

--- a/tests/test_numpy_dtypes.cpp
+++ b/tests/test_numpy_dtypes.cpp
@@ -297,6 +297,22 @@ test_initializer numpy_dtypes([](py::module &m) {
     m.def("test_array_ctors", &test_array_ctors);
     m.def("test_dtype_ctors", &test_dtype_ctors);
     m.def("test_dtype_methods", &test_dtype_methods);
+
+    py::class_<py::dtype::record_builder>(m, "record_builder")
+        .def(py::init<size_t>())
+        .def("add",
+             [](py::dtype::record_builder& self, const std::string& name, size_t offset, py::object type) {
+                 return self.add(name, offset, py::dtype::from_args(type));
+             })
+        .def("build", [](const py::dtype::record_builder& self) { return self.build(); });
+
+    py::class_<py::dtype::packed_record_builder>(m, "packed_record_builder")
+        .def(py::init<>())
+        .def("add",
+             [](py::dtype::packed_record_builder& self, const std::string& name, py::object type) {
+                 return self.add(name, py::dtype::from_args(type));
+             })
+        .def("build", [](const py::dtype::packed_record_builder& self) { return self.build(); });
 });
 
 #undef PYBIND11_PACKED

--- a/tests/test_numpy_dtypes.py
+++ b/tests/test_numpy_dtypes.py
@@ -31,6 +31,22 @@ def test_format_descriptors():
 
 
 @pytest.requires_numpy
+def test_record_builders():
+    import numpy as np
+    from pybind11_tests import record_builder as rb, packed_record_builder as prb
+
+    assert rb(0).build() == np.dtype([])
+    assert rb(1).build() == np.dtype({'names': [], 'formats': [], 'offsets': [], 'itemsize': 1})
+    assert rb(10).add('foo', 8, '?').add('bar', 2, 'f4').build() == \
+        np.dtype({'names': ['bar', 'foo'], 'formats': ['f4', '?'], 'offsets': [2, 8], 'itemsize': 10})
+    with pytest.raises(ValueError):
+        rb(10).add('foo', 8, 'i4').build()
+
+    assert prb().build() == np.dtype([])
+    assert prb().add('foo', '?').add('bar', 'f4').build() == np.dtype([('foo', '?'), ('bar', 'f4')])
+
+
+@pytest.requires_numpy
 def test_dtype():
     from pybind11_tests import print_dtypes, test_dtype_ctors, test_dtype_methods
 

--- a/tests/test_numpy_vectorize.py
+++ b/tests/test_numpy_vectorize.py
@@ -18,13 +18,13 @@ def test_vectorize(capture):
             assert np.isclose(f(np.array(1), np.array(2), 3), 6)
         assert capture == "my_func(x:int=1, y:float=2, z:float=3)"
         with capture:
-            assert np.allclose(f(np.array([1, 3]), np.array([2, 4]), 3), [6, 36])
+            assert np.allclose(f(np.array([1, 3], 'i'), np.array([2, 4], 'f'), 3), [6, 36])
         assert capture == """
             my_func(x:int=1, y:float=2, z:float=3)
             my_func(x:int=3, y:float=4, z:float=3)
         """
         with capture:
-            a, b, c = np.array([[1, 3, 5], [7, 9, 11]]), np.array([[2, 4, 6], [8, 10, 12]]), 3
+            a, b, c = np.array([[1, 3, 5], [7, 9, 11]], 'i'), np.array([[2, 4, 6], [8, 10, 12]], 'f'), 3
             assert np.allclose(f(a, b, c), a * b * c)
         assert capture == """
             my_func(x:int=1, y:float=2, z:float=3)
@@ -35,7 +35,7 @@ def test_vectorize(capture):
             my_func(x:int=11, y:float=12, z:float=3)
         """
         with capture:
-            a, b, c = np.array([[1, 2, 3], [4, 5, 6]]), np.array([2, 3, 4]), 2
+            a, b, c = np.array([[1, 2, 3], [4, 5, 6]], 'i'), np.array([2, 3, 4], 'f'), 2
             assert np.allclose(f(a, b, c), a * b * c)
         assert capture == """
             my_func(x:int=1, y:float=2, z:float=2)
@@ -46,7 +46,7 @@ def test_vectorize(capture):
             my_func(x:int=6, y:float=4, z:float=2)
         """
         with capture:
-            a, b, c = np.array([[1, 2, 3], [4, 5, 6]]), np.array([[2], [3]]), 2
+            a, b, c = np.array([[1, 2, 3], [4, 5, 6]], 'i'), np.array([[2], [3]], 'f'), 2
             assert np.allclose(f(a, b, c), a * b * c)
         assert capture == """
             my_func(x:int=1, y:float=2, z:float=2)


### PR DESCRIPTION
- Initial rework of array / array_t, add new flags, change defaults, remove forcecast
- Tighten dtypes in a few NumPy / Eigen tests
- Add `handle::is_none()` method
- Improve string formatting in `error_already_set`
- Implement fast versions of `dtype::itemsize()`, `dtype::kind()`, `dtype::has_fields()`, `array::dtype()` via NumPy C API
- Implement `array::ndim()`, `array::shape()`, `array::strides()`, `array::shape(size_t)`, `array::strides(size_t)` via NumPy C API
- Implement `array::data()` via NumPy C API that allows accessing the underlying data pointer without having to request a buffer

Few random notes:
- The whole `array::in`, `array_in` etc situation I'm not 100% sure about -- this is purely syntax sugar and may be done differently
- The flags are redefined in `array` so as not to break old code
- The `array` is non-generic so as not to break old code, it's possible to have it generic by using `generic_array`
- `PyArray_Proxy` and `PyArray_Proxy` represent the leading sections of their NumPy counterparts; I've checked, they are compatible with NumPy API 1.6-1.11 at the very least (I haven't checked <=1.5, since that would be pre-2010); these sections are not likely to be ever changed upstream.

TODO:
- [x] handle_load_options -> load_options, ignore_error_already_set -> propagate_errors, don't use boolean literals in enums
- [ ] Implement support for different casting rules for `array_t` (one more type param?)
- [ ] Implement `.astype()` for arrays
- [ ] Implement support for wrapping owned pointers (accept optional `owner`)
- [x] Implement direct `.data()` access to the underlying data, bypassing buffer API
- [ ] Make vectorize helper more flexible flags/casting-wise?
- [ ] Add `zeros` ctor (`empty` as well?)
- [ ] Add array indexing (`data_at` or `operator[]`?)
- [ ] Write rigorous tests for all of the new/changed stuff
